### PR TITLE
fix path to cache folder when running from a sub folder

### DIFF
--- a/services/CompressorService.php
+++ b/services/CompressorService.php
@@ -22,7 +22,7 @@ class CompressorService extends BaseApplicationComponent
     public function __construct()
     {
         $this->document_root = $_SERVER['DOCUMENT_ROOT'];
-        $this->cache_dir = $this->document_root . "/cache";
+        $this->cache_dir = realpath(IOHelper::getFolder(__FILE__)) . "/cache";
         $this->cache_url = $this->makeBaseCacheUrl();
 
         IOHelper::ensureFolderExists($this->cache_dir);


### PR DESCRIPTION
(eg http://localhost/example.com)

It was trying to create /cache in the web root, not site root.

Thanks to Brad Bell (brad@pixelandtonic.com) for the assistance.